### PR TITLE
Fix target creation bugs

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -13,7 +13,8 @@
 # Class to register users targets in map
 class Target < ActiveRecord::Base
   validates :title, :topic, :latitude, :longitude, presence: true
-  validates :size, presence: true, numericality: true, inclusion: 100..500
+  validates :size, presence: true,
+                   numericality: { greater_than_or_equal_to: 50, less_than_or_equal_to: 500 }
 
   TOPICS = [
     {

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -28,6 +28,8 @@
     if (marker) {
       marker.setMap(null);
     }
+    document.getElementById('target_latitude').value = null;
+    document.getElementById('target_longitude').value = null;
   }
 
   function placeMarkerAndPanTo(latLng, map) {

--- a/app/views/targets/index.html.erb
+++ b/app/views/targets/index.html.erb
@@ -23,10 +23,14 @@
 
     function showErrorAlert(event) {
       var errors = event.detail[0]['errors'];
-      if (errors.latitude){
+      if (errors.latitude) {
         toastr.warning('<%=I18n.t(:alert_error_target_not_set)%>');
       } else {
-        toastr.warning('<%=I18n.t(:alert_error_target_data_incomplete)%>');
+        if (errors.size) {
+          toastr.warning('<%=I18n.t(:alert_error_target_size_invalid)%>');
+        } else {
+          toastr.warning('<%=I18n.t(:alert_error_target_data_incomplete)%>');
+        }
       }
     }
   });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   alert_success_target_created: "Target created!"
   alert_error_target_not_set: "Target not set on the map."
   alert_error_target_data_incomplete: "Target data incomplete."
+  alert_error_target_size_invalid: "Target size should be a number between 50 and 500."
 
   # Labels
   label_target_title: "Title"


### PR DESCRIPTION
Fix 2 bugs that emerged from the feedback of the presentation of the target creation feature:
- When a target was created, the following target creation didn't request to place the marker on the map.
- The validation message for the target size was the generic form error message. It was replaced with a specific message.